### PR TITLE
Fe 1638

### DIFF
--- a/core/model/model.js
+++ b/core/model/model.js
@@ -7,7 +7,7 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
                 modelConfig,
                 namespace;
             // Convert name of the model eg. Yd.Models.Location -> §yd-models-locations
-            modelName = "§" +self.fullName.toLowerCase().replace(/\./g, "-");
+            modelName = "@" +self.fullName.toLowerCase().replace(/\./g, "-");
             namespace = steal.config("namespace");
             // We process only models from the namespace
             if (self.fullName.indexOf(namespace+'.Models') === 0) {

--- a/core/model/model.js
+++ b/core/model/model.js
@@ -1,7 +1,6 @@
 steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
     "use strict";
     can.extend(can.Model, {
-
         cacheDeferred: function (methodName, params, success, error, reset, data) {
             var current, index = can.param(params),
                 objectName = "deferred_" + methodName,
@@ -143,34 +142,61 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
             }
             return model;
         },
-        ajaxRequest: function (options, success, error) {
-            if (typeof options !== "string") {
-                var def = can.Deferred(),
-                    modelName = this._fullName.replace(/_/g, "-"),
-                    self = this;
-                if (!self.mapper) {
-                    steal(steal.config(steal.config("namespace")).jigs["models"]["§" + modelName].mapper, function (mapper) {
-                        self.mapper = mapper;
-                        self.mapper.mapperName = modelName + "Mapper";
-                        def.resolve(options, success, error);
+        ajaxRequest: function(settings){
+            var self = this,
+                mapper,
+                result;
+            mapper = self.mapper(settings);
+            if (mapper) {
+                result = can.Deferred();
+                can.ajax(settings)
+                    .then(function(response){
+                        result.resolve(mapper(response));
+                    })
+                    .fail(function(){
+                        result.reject(arguments);
                     });
-                } else {
-                    def.resolve(options, success, error);
-                }
-
-                def.done(function (options, success, error) {
-                    can.ajax({
-                        type: options.type || "GET",
-                        cache: options.cache || true,
-                        url: options.url,
-                        data: options.data || null,
-                        dataType: options.dataType,
-                        success: function(data){ success(data, self.mapper) },
-                        error: error
-                    });
-                });
             }
+            else {
+                result = can.ajax(settings);
+            }
+            return result;
+        },
+        mapper: function () {
+            // default mapper;
+            return function(data){
+                return data;
+            };
         }
+//            function (options, success, error) {
+//            if (typeof options !== "string") {
+//                var def = can.Deferred(),
+//                    modelName = this._fullName.replace(/_/g, "-"),
+//                    self = this;
+//                if (!self.mapper) {
+////                    steal(steal.config(steal.config("namespace")).jigs["models"]["§" + modelName].mapper, function (mapper) {
+//                    steal(steal.config(steal.config("namespace")).models["§" + modelName].mapper, function (mapper) {
+//                        self.mapper = mapper;
+//                        self.mapper.mapperName = modelName + "Mapper";
+//                        def.resolve(options, success, error);
+//                    });
+//                } else {
+//                    def.resolve(options, success, error);
+//                }
+//
+//                def.done(function (options, success, error) {
+//                    can.ajax({
+//                        type: options.type || "GET",
+//                        cache: options.cache || true,
+//                        url: options.url,
+//                        data: options.data || null,
+//                        dataType: options.dataType,
+//                        success: function(data){ success(data, self.mapper) },
+//                        error: error
+//                    });
+//                });
+//            }
+//        }
     });
     can.extend(can.List.prototype, {
         store: function (model) {
@@ -321,7 +347,7 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
                     a = a[comparator];
                     b = b[comparator];
                     return a === b ? 0 : (a < b ? -1 : 1
-                        );
+                    );
                 }],
                 res = [].sort.apply(this, args);
             !silent && can.trigger(this, "reset");
@@ -414,7 +440,7 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
                 len = _reference.length;
                 if (len > 15 &&  /// length of http://a/a.json
                     (_reference.indexOf('http') === 0
-                        ) && _reference.indexOf('.json') === len - 5) {
+                    ) && _reference.indexOf('.json') === len - 5) {
                     result = {isOk: true, result: _reference};
                 }
             }
@@ -441,10 +467,10 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
             self['__deffered' + attributeName + '__'] = deferred;
 
             succesCalls = self['__deffered_succes' + attributeName + '__'] = (typeof success === 'function'
-                ) ? [success] : [];
+            ) ? [success] : [];
             deferred.done(succesCalls);
             errorCalls = self['__deffered_succes' + attributeName + '__'] = (typeof error === 'function'
-                ) ? [error] : [];
+            ) ? [error] : [];
             deferred.fail(errorCalls);
             return deferred;
         },
@@ -527,6 +553,6 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
             }
         }
     });
-    
+
     return can;
 });

--- a/core/model/model.js
+++ b/core/model/model.js
@@ -143,7 +143,7 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
             }
             return model;
         },
-        ajax2: function (options, success, error) {
+        ajaxRequest: function (options, success, error) {
             if (typeof options !== "string") {
                 var def = can.Deferred(),
                     modelName = this._fullName.replace(/_/g, "-");
@@ -158,8 +158,10 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
 
                 def.done(function (options, success, error) {
                     can.ajax({
+                        type: options.type || "GET",
+                        cache: options.cache || true,
                         url: options.url,
-                        data: options.data,
+                        data: options.data || null,
                         dataType: options.dataType,
                         success: function(data){ success(data, self.mapper) },
                         error: error

--- a/core/model/model.js
+++ b/core/model/model.js
@@ -6,7 +6,6 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
                 modelName,
                 modelConfig,
                 namespace,
-                apicalls;
             // Convert name of the model eg. Yd.Models.Location -> §yd-models-locations
             modelName = "§" +self.fullName.toLowerCase().replace(/\./g, "-");
             namespace = steal.config("namespace");
@@ -312,8 +311,8 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
                 if (typeof apicall === 'undefined') {
                     throw Error('Configuration for "'+apicall+'" apicall is not provided for the model '+self.fullName);
                 }
-                self._getPlaceholders(apicallConfig.path).every(function(item){
-                    if (typeof placeholders[item] === 'undefined') {
+                self._getPlaceholders(apicallConfig.path).forEach(function(item){
+                    if (!Object.prototype.hasOwnProperty.call(placeholders, item)) {
                         throw Error('Placeholder for the key "'+item+'"'
                             +' is not provided in ajaxRequest of model '+ self.fullName);
                     }

--- a/core/model/model.js
+++ b/core/model/model.js
@@ -173,7 +173,7 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
                 // Explicitly takeoff success and error handlers from settings and hook them
                 // to result promise. That will prevent calling of them after can.ajax call.
                 if (settings && settings.success) {
-                    result.then(settings.success);
+                    result.done(settings.success);
                     delete settings.success;
                 }
                 if (settings && settings.error) {
@@ -181,13 +181,16 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
                     delete settings.error;
                 }
                 // perform ajax call
-                can.ajax(settings)
-                    .then(function(response){
+                can.ajax(settings).then(
+                    // Success
+                    function(response){
                         result.resolve(mapper(response));
-                    })
-                    .fail(function(){
+                    },
+                    // Error
+                    function(){
                         result.reject(arguments);
-                    });
+                    }
+                );
             }
             else {
                 //if no mapper found, then only do the ajax request

--- a/core/model/model.js
+++ b/core/model/model.js
@@ -232,7 +232,8 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
                 result,
                 settings,
                 apicallSettings;
-            // prepare apicall settings
+
+            // 1. prepare apicall settings
             apicallSettings = self._getApiCallSettings(requestSettings);
 
             if (apicallSettings) {
@@ -250,7 +251,7 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
                 settings = requestSettings;
             }
 
-            // get mapper and make an ajax call
+            // 2. get mapper and make an ajax call
             mapper = self._getMapper(requestSettings);
             if (mapper) {
                 result = can.Deferred();

--- a/core/model/model.js
+++ b/core/model/model.js
@@ -146,10 +146,12 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
         ajaxRequest: function (options, success, error) {
             if (typeof options !== "string") {
                 var def = can.Deferred(),
-                    modelName = this._fullName.replace(/_/g, "-");
+                    modelName = this._fullName.replace(/_/g, "-"),
+                    self = this;
                 if (!self.mapper) {
-                    steal(steal.config(steal.config("namespace")).models["§" + modelName].mapper, function (mapper) {
+                    steal(steal.config(steal.config("namespace")).jigs["models"]["§" + modelName].mapper, function (mapper) {
                         self.mapper = mapper;
+                        self.mapper.mapperName = modelName + "Mapper";
                         def.resolve(options, success, error);
                     });
                 } else {

--- a/core/model/model.js
+++ b/core/model/model.js
@@ -14,8 +14,7 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
             if (self.fullName.indexOf(namespace+'.Models') === 0) {
                 modelConfig = steal.config(namespace).jigs[modelName];
                 if (modelConfig) {
-                    //can.extend(true, self._config, modelConfig);
-                    self._config = modelConfig;
+                    can.extend(true, self._config, modelConfig);
                 }
                 else {
                     console.warn('No config for the model '+self.fullName+' found. '
@@ -238,6 +237,12 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
 
             if (apicallSettings) {
                 settings = can.extend(apicallSettings,requestSettings.params);
+                if (requestSettings.success) {
+                    settings.success = requestSettings.success;
+                }
+                if (requestSettings.error) {
+                    settings.error = requestSettings.error;
+                }
             }
             else {
                 // for bacward compatibility if no apicallsettings set
@@ -288,8 +293,8 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
             if (typeof apicall === 'undefined') {
                 // Before refactoring of the models to use apicall we only warn.
                 console.warn('DEPRICATED."apicall" key is not provided. in .ajaxRequest()'
-                +'For the model '+ self.fullName
-                + ' Please, rewrite this model to use "apicall" settings. ');
+                    +'For the model '+ self.fullName
+                    + ' Please, rewrite this model to use "apicall" settings. ');
                 result = null;
             }
             else {
@@ -309,7 +314,7 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
                 self._getPlaceholders(apicallConfig.path).every(function(item){
                     if (typeof placeholders[item] === 'undefined') {
                         throw Error('Placeholder for the key "'+item+'"'
-                        +' is not provided in ajaxRequest of model '+ self.fullName);
+                            +' is not provided in ajaxRequest of model '+ self.fullName);
                     }
                     url = url.replace('{'+item+'}',placeholders[item]);
                 });

--- a/core/model/model.js
+++ b/core/model/model.js
@@ -5,7 +5,7 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
             var self = this,
                 modelName,
                 modelConfig,
-                namespace,
+                namespace;
             // Convert name of the model eg. Yd.Models.Location -> §yd-models-locations
             modelName = "§" +self.fullName.toLowerCase().replace(/\./g, "-");
             namespace = steal.config("namespace");

--- a/core/model/model.js
+++ b/core/model/model.js
@@ -122,12 +122,12 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
             if (can.Model.deferred_findOne
                 && can.Model.deferred_findOne[this._fullName]) {
                 delete (can.Model.deferred_findOne[this._fullName]
-                    );
+                );
             }
             if (can.Model.deferred_findAll
                 && can.Model.deferred_findAll[this._fullName]) {
                 delete (can.Model.deferred_findAll[this._fullName]
-                    );
+                );
             }
             if ($.jStorage.get(this._fullName)) {
                 $.jStorage.deleteKey(this._fullName);
@@ -142,6 +142,30 @@ steal("can/model", "can/map/delegate", "jquery/jstorage", function () {
                 }
             }
             return model;
+        },
+        ajax2: function (options, success, error) {
+            if (typeof options !== "string") {
+                var def = can.Deferred(),
+                    modelName = this._fullName.replace(/_/g, "-");
+                if (!self.mapper) {
+                    steal(steal.config(steal.config("namespace")).models["§" + modelName].mapper, function (mapper) {
+                        self.mapper = mapper;
+                        def.resolve(options, success, error);
+                    });
+                } else {
+                    def.resolve(options, success, error);
+                }
+
+                def.done(function (options, success, error) {
+                    can.ajax({
+                        url: options.url,
+                        data: options.data,
+                        dataType: options.dataType,
+                        success: function(data){ success(data, self.mapper) },
+                        error: error
+                    });
+                });
+            }
         }
     });
     can.extend(can.List.prototype, {

--- a/steal-types/conf/conf.js
+++ b/steal-types/conf/conf.js
@@ -76,7 +76,7 @@
                 init = function (e) {
                     if (e.type == 'readystatechange' && doc.readyState != 'complete') return;
                     (e.type == 'load' ? win : doc
-                        )[rem](pre + e.type, init, false);
+                    )[rem](pre + e.type, init, false);
                     if (!done && (done = true
                         )) fn.call(win, e.type || e);
                 },
@@ -460,8 +460,10 @@
             if (config.jigs) {
                 var jigsKeys = Object.keys(config.jigs);
                 for (var i = 0; i < jigsKeys.length; i++) {
-                    executeJigSlotLogic(jigsKeys[i], config.jigs[jigsKeys[i]]);
-                    prepareJig(config, jigsKeys[i], config.jigs[jigsKeys[i]]);
+                    if (jigsKeys[i][0]!=="§") {
+                        executeJigSlotLogic(jigsKeys[i], config.jigs[jigsKeys[i]]);
+                        prepareJig(config, jigsKeys[i], config.jigs[jigsKeys[i]]);
+                    }
                 }
             }
 
@@ -486,7 +488,7 @@
                 if (!steal.config("isBuild") && steal.config("domain") !== "default") {
                     steal(config.localePath, function () {
                         steal.apply(steal, config.includes);
-                   });
+                    });
                 } else {
                     steal.apply(steal, config.includes);
                 }

--- a/steal-types/conf/conf.js
+++ b/steal-types/conf/conf.js
@@ -840,6 +840,12 @@
         if (!config) {
             error("Config can't be parsed");
         }
+        if (config.process === false) {
+            // if we have process:false it will allow the object inside .conf
+            // to get in stealing file as a variable (but not processed)
+            options.text = 'steal(function() { return ' + options.text + ';});';
+            return success();
+        }
         // ignore this config to load in production
         //options.ignore = true;
         if (!config.includes) {

--- a/tap.log
+++ b/tap.log
@@ -1,0 +1,220 @@
+TAP version 13
+# Test: Test: /home/jaroslav/repos/ydSelenium/Suites/lieferando_live/001_Login_AllPages.json
+ok 1 {"type":"store","text":"https://www.lieferando.de","variable":"domain"}
+ok 2 {"type":"store","text":"Selenium","variable":"prename"}
+ok 3 {"type":"store","text":"Tester","variable":"name"}
+ok 4 {"type":"store","text":"selenium@ydqa.de","variable":"email"}
+ok 5 {"type":"store","text":"testen","variable":"password"}
+ok 6 {"type":"store","text":"Selenium Tester","variable":"fullname"}
+ok 7 {"type":"store","text":"Teststreet","variable":"street"}
+ok 8 {"type":"store","text":"13","variable":"streetnumber"}
+ok 9 {"type":"store","text":"016018188841","variable":"phone"}
+ok 10 {"type":"store","text":"01070 Test-Gebiet-1","variable":"location"}
+ok 11 {"type":"store","text":"Selenium GmbH","variable":"company"}
+ok 12 {"type":"store","text":"13th Floor","variable":"floor"}
+ok 13 {"type":"store","text":"This is a test order by Selenium. DO NOT prepare or charge!","variable":"comment"}
+ok 14 {"type":"storeEval","script":"return Math.floor(Math.random()*1111111)","variable":"random"}
+ok 15 {"type":"get","url":"${domain}"}
+ok 16 {"type":"assertEval","script":"$.jStorage.flush()","value":"null"}
+ok 17 {"type":"refresh"}
+ok 18 {"type":"print","text":"MESSAGE: Page loaded!"}
+ok 19 {"type":"clickElement","locator":{"type":"css selector","value":"a.yd-jig-header-login-button"}}
+ok 20 {"type":"setElementText","locator":{"type":"css selector","value":"input[type=\"email\"]"},"text":"${email}"}
+ok 21 {"type":"setElementText","locator":{"type":"css selector","value":"input[type=\"password\"]"},"text":"${password}"}
+ok 22 {"type":"clickElement","locator":{"type":"css selector","value":"button.yd-btn-s.yd-btn-interact"}}
+ok 23 {"type":"print","text":"MESSAGE: User logged in!"}
+ok 24 {"type":"clickElement","locator":{"type":"css selector","value":"div.yd-jig-header-dropdown.yd-jig-header-dropdown-user"}}
+ok 25 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"a.yd-jig-header-logout-link"}}
+ok 26 {"type":"clickElement","locator":{"type":"css selector","value":"a.yd-jig-header-logout-link"}}
+ok 27 {"type":"print","text":"MESSAGE: User logged out!"}
+ok 28 {"type":"setElementText","locator":{"type":"css selector","value":"#yd-jig-plz-search"},"text":"01070"}
+ok 29 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"#ui-id-5"}}
+ok 30 {"type":"clickElement","locator":{"type":"css selector","value":"#ui-id-5"}}
+ok 31 {"type":"print","text":"MESSAGE: Testarea opened!"}
+ok 32 {"type":"clickElement","locator":{"type":"css selector","value":"a.yd-jig-header-login-button"}}
+ok 33 {"type":"setElementText","locator":{"type":"css selector","value":"input[type=\"email\"]"},"text":"${email}"}
+ok 34 {"type":"setElementText","locator":{"type":"css selector","value":"input[type=\"password\"]"},"text":"${password}"}
+ok 35 {"type":"clickElement","locator":{"type":"css selector","value":"button.yd-btn-s.yd-btn-interact"}}
+ok 36 {"type":"print","text":"MESSAGE: User logged in!"}
+ok 37 {"type":"clickElement","locator":{"type":"css selector","value":"div.yd-jig-header-dropdown.yd-jig-header-dropdown-user"}}
+ok 38 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"a.yd-jig-header-logout-link"}}
+ok 39 {"type":"clickElement","locator":{"type":"css selector","value":"a.yd-jig-header-logout-link"}}
+ok 40 {"type":"print","text":"MESSAGE: User logged out!"}
+ok 41 {"type":"clickElement","locator":{"type":"link text","value":"QA Restaurant SELENIUM"}}
+ok 42 {"type":"print","text":"MESSAGE: QA Resto opened!"}
+ok 43 {"type":"clickElement","locator":{"type":"link text","value":"Menüs"}}
+ok 44 {"type":"clickElement","locator":{"type":"xpath","value":"//div[@class='yd-content']/div/div/div[1]/section[1]/div[2]/div/div[2]/div[2]/a"}}
+ok 45 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"section.yd-jig-additions.yd_jig_additions > div.yd-jig-lightbox-content"}}
+ok 46 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[1]/div[2]/ul/li[9]/button"}}
+ok 47 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 48 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[2]/div[2]/ul/li[5]/button"}}
+ok 49 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 50 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[1]/button"}}
+ok 51 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 52 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[1]/button"}}
+ok 53 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 54 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[8]/button"}}
+ok 55 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 56 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[8]/button"}}
+ok 57 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 58 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[8]/button"}}
+ok 59 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 60 {"type":"sendKeysToElement","locator":{"type":"css selector","value":"textarea.yd-jig-additions-comment"},"text":"This is a meal comment! Get some food!"}
+ok 61 {"type":"clickElement","locator":{"type":"css selector","value":"textarea.yd-jig-additions-comment"}}
+ok 62 {"type":"verifyElementValue","locator":{"type":"css selector","value":"textarea.yd-jig-additions-comment"},"value":"This is a meal comment! Get some food!"}
+ok 63 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[2]/div[2]/button"}}
+ok 64 {"type":"print","text":"MESSAGE: Meal added to cart!"}
+ok 65 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"a.yd-btn-l.yd-btn-order"}}
+ok 66 {"type":"clickElement","locator":{"type":"css selector","value":"a.yd-btn-l.yd-btn-order"}}
+ok 67 {"type":"print","text":"MESSAGE: Go to checkout!"}
+ok 68 {"type":"clickElement","locator":{"type":"css selector","value":"a.yd-jig-header-login-button"}}
+ok 69 {"type":"setElementText","locator":{"type":"css selector","value":"input[type=\"email\"]"},"text":"${email}"}
+ok 70 {"type":"setElementText","locator":{"type":"css selector","value":"input[type=\"password\"]"},"text":"${password}"}
+ok 71 {"type":"clickElement","locator":{"type":"css selector","value":"button.yd-btn-s.yd-btn-interact"}}
+ok 72 {"type":"print","text":"MESSAGE: User logged in!"}
+ok 73 {"type":"clickElement","locator":{"type":"css selector","value":"div.yd-jig-header-dropdown.yd-jig-header-dropdown-user"}}
+ok 74 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"a.yd-jig-header-logout-link"}}
+ok 75 {"type":"clickElement","locator":{"type":"css selector","value":"a.yd-jig-header-logout-link"}}
+ok 76 {"type":"print","text":"MESSAGE: User logged out!"}
+ok 77 {"type":"setElementText","locator":{"type":"css selector","value":"input[name=\"prename\"]"},"text":"${prename}"}
+ok 78 {"type":"setElementText","locator":{"type":"css selector","value":"input[name=\"name\"]"},"text":"${name}"}
+ok 79 {"type":"setElementText","locator":{"type":"css selector","value":"input[name=\"street\"]"},"text":"${street}"}
+ok 80 {"type":"setElementText","locator":{"type":"css selector","value":"input[name=\"number\"]"},"text":"${streetnumber}"}
+not ok 81 Timeout appears 300000 | {"type":"setElementText","locator":{"type":"css selector","value":"input[name=\"tel\"]"},"text":"${phone}"}
+  ---
+    operator: ok
+    expected: true
+    actual:   false
+    at: log (/home/jaroslav/repos/JigMagga/tasks/se-interpreter.js:38:26)
+  ...
+# Test: Test: /home/jaroslav/repos/ydSelenium/Suites/lieferando_live/002_Payment_Cash_NoDiscount.json
+ok 82 {"type":"store","text":"https://www.lieferando.de","variable":"domain"}
+ok 83 {"type":"store","text":"Selenium","variable":"prename"}
+ok 84 {"type":"store","text":"Tester","variable":"name"}
+ok 85 {"type":"store","text":"selenium@ydqa.de","variable":"email"}
+ok 86 {"type":"store","text":"testen","variable":"password"}
+ok 87 {"type":"store","text":"Selenium Tester","variable":"fullname"}
+ok 88 {"type":"store","text":"Teststreet","variable":"street"}
+ok 89 {"type":"store","text":"13","variable":"streetnumber"}
+ok 90 {"type":"store","text":"016018188841","variable":"phone"}
+ok 91 {"type":"store","text":"01070 Test-Gebiet-1","variable":"location"}
+ok 92 {"type":"store","text":"Selenium GmbH","variable":"company"}
+ok 93 {"type":"store","text":"13th Floor","variable":"floor"}
+ok 94 {"type":"store","text":"This is a test order by Selenium. DO NOT prepare or charge!","variable":"comment"}
+ok 95 {"type":"storeEval","script":"return Math.floor(Math.random()*1111111)","variable":"random"}
+ok 96 {"type":"get","url":"${domain}"}
+ok 97 {"type":"assertEval","script":"$.jStorage.flush()","value":"null"}
+ok 98 {"type":"refresh"}
+ok 99 {"type":"print","text":"MESSAGE: Page loaded!"}
+ok 100 {"type":"clickElement","locator":{"type":"css selector","value":"a.yd-jig-header-login-button"}}
+ok 101 {"type":"setElementText","locator":{"type":"css selector","value":"input[type=\"email\"]"},"text":"${email}"}
+ok 102 {"type":"setElementText","locator":{"type":"css selector","value":"input[type=\"password\"]"},"text":"${password}"}
+ok 103 {"type":"clickElement","locator":{"type":"css selector","value":"button.yd-btn-s.yd-btn-interact"}}
+ok 104 {"type":"print","text":"MESSAGE: User logged in!"}
+ok 105 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"div.yd-jig-header-dropdown.yd-jig-header-dropdown-user"}}
+ok 106 {"type":"clickElement","locator":{"type":"css selector","value":"#yd-jig-plz-dashboard-search"}}
+ok 107 {"type":"setElementText","locator":{"type":"css selector","value":"#yd-jig-plz-dashboard-search"},"text":"01070"}
+ok 108 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"#ui-id-5"}}
+ok 109 {"type":"clickElement","locator":{"type":"css selector","value":"#ui-id-5"}}
+ok 110 {"type":"print","text":"MESSAGE: Testarea opened!"}
+ok 111 {"type":"clickElement","locator":{"type":"link text","value":"QA Restaurant SELENIUM"}}
+ok 112 {"type":"print","text":"MESSAGE: QA Resto opened!"}
+ok 113 {"type":"clickElement","locator":{"type":"link text","value":"Menüs"}}
+ok 114 {"type":"clickElement","locator":{"type":"xpath","value":"//div[@class='yd-content']/div/div/div[1]/section[1]/div[2]/div/div[2]/div[2]/a"}}
+ok 115 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"section.yd-jig-additions.yd_jig_additions > div.yd-jig-lightbox-content"}}
+ok 116 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[1]/div[2]/ul/li[9]/button"}}
+ok 117 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 118 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[2]/div[2]/ul/li[5]/button"}}
+ok 119 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 120 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[1]/button"}}
+ok 121 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 122 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[1]/button"}}
+ok 123 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 124 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[8]/button"}}
+ok 125 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 126 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[8]/button"}}
+ok 127 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 128 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[8]/button"}}
+ok 129 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 130 {"type":"sendKeysToElement","locator":{"type":"css selector","value":"textarea.yd-jig-additions-comment"},"text":"This is a meal comment! Get some food!"}
+ok 131 {"type":"clickElement","locator":{"type":"css selector","value":"textarea.yd-jig-additions-comment"}}
+ok 132 {"type":"verifyElementValue","locator":{"type":"css selector","value":"textarea.yd-jig-additions-comment"},"value":"This is a meal comment! Get some food!"}
+ok 133 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[2]/div[2]/button"}}
+ok 134 {"type":"print","text":"MESSAGE: Meal added to cart!"}
+ok 135 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"a.yd-btn-l.yd-btn-order"}}
+ok 136 {"type":"clickElement","locator":{"type":"css selector","value":"a.yd-btn-l.yd-btn-order"}}
+ok 137 {"type":"print","text":"MESSAGE: Go to checkout!"}
+ok 138 {"type":"clickElement","locator":{"type":"css selector","value":"div.yd-jig-partnerdiscountselect-choice.yd-jig-discount-without.yd-discount-without"}}
+ok 139 {"type":"setElementText","locator":{"type":"css selector","value":"input[name=\"tel\"]"},"text":"${phone}"}
+ok 140 {"type":"setElementText","locator":{"type":"css selector","value":"input[name=\"name\"]"},"text":"${name}"}
+ok 141 {"type":"setElementText","locator":{"type":"css selector","value":"input[name=\"street\"]"},"text":"${street}"}
+ok 142 {"type":"setElementText","locator":{"type":"css selector","value":"input[name=\"number\"]"},"text":"${streetnumber}"}
+ok 143 {"type":"setElementText","locator":{"type":"css selector","value":"input[name=\"tel\"]"},"text":"${phone}"}
+not ok 144 Timeout appears 300000 | {"type":"setElementText","locator":{"type":"css selector","value":"input[name=\"email\"]"},"text":"${email}"}
+  ---
+    operator: ok
+    expected: true
+    actual:   false
+    at: log (/home/jaroslav/repos/JigMagga/tasks/se-interpreter.js:38:26)
+  ...
+# Test: Test: /home/jaroslav/repos/ydSelenium/Suites/lieferando_live/003_Payment_Cash_PartnerDiscount.json
+ok 145 {"type":"store","text":"https://www.lieferando.de","variable":"domain"}
+ok 146 {"type":"store","text":"Selenium","variable":"prename"}
+ok 147 {"type":"store","text":"Tester","variable":"name"}
+ok 148 {"type":"store","text":"selenium@ydqa.de","variable":"email"}
+ok 149 {"type":"store","text":"testen","variable":"password"}
+ok 150 {"type":"store","text":"Selenium Tester","variable":"fullname"}
+ok 151 {"type":"store","text":"Teststreet","variable":"street"}
+ok 152 {"type":"store","text":"13","variable":"streetnumber"}
+ok 153 {"type":"store","text":"016018188841","variable":"phone"}
+ok 154 {"type":"store","text":"01070 Test-Gebiet-1","variable":"location"}
+ok 155 {"type":"store","text":"Selenium GmbH","variable":"company"}
+ok 156 {"type":"store","text":"13th Floor","variable":"floor"}
+ok 157 {"type":"store","text":"This is a test order by Selenium. DO NOT prepare or charge!","variable":"comment"}
+ok 158 {"type":"storeEval","script":"return Math.floor(Math.random()*1111111)","variable":"random"}
+ok 159 {"type":"get","url":"${domain}"}
+ok 160 {"type":"assertEval","script":"$.jStorage.flush()","value":"null"}
+ok 161 {"type":"refresh"}
+ok 162 {"type":"print","text":"MESSAGE: Page loaded!"}
+ok 163 {"type":"clickElement","locator":{"type":"css selector","value":"a.yd-jig-header-login-button"}}
+ok 164 {"type":"setElementText","locator":{"type":"css selector","value":"input[type=\"email\"]"},"text":"${email}"}
+ok 165 {"type":"setElementText","locator":{"type":"css selector","value":"input[type=\"password\"]"},"text":"${password}"}
+ok 166 {"type":"clickElement","locator":{"type":"css selector","value":"button.yd-btn-s.yd-btn-interact"}}
+ok 167 {"type":"print","text":"MESSAGE: User logged in!"}
+ok 168 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"div.yd-jig-header-dropdown.yd-jig-header-dropdown-user"}}
+ok 169 {"type":"clickElement","locator":{"type":"css selector","value":"#yd-jig-plz-dashboard-search"}}
+ok 170 {"type":"setElementText","locator":{"type":"css selector","value":"#yd-jig-plz-dashboard-search"},"text":"01070"}
+ok 171 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"#ui-id-5"}}
+ok 172 {"type":"clickElement","locator":{"type":"css selector","value":"#ui-id-5"}}
+ok 173 {"type":"print","text":"MESSAGE: Testarea opened!"}
+ok 174 {"type":"clickElement","locator":{"type":"link text","value":"QA Restaurant SELENIUM"}}
+ok 175 {"type":"print","text":"MESSAGE: QA Resto opened!"}
+ok 176 {"type":"clickElement","locator":{"type":"link text","value":"Menüs"}}
+ok 177 {"type":"clickElement","locator":{"type":"xpath","value":"//div[@class='yd-content']/div/div/div[1]/section[1]/div[2]/div/div[2]/div[2]/a"}}
+ok 178 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"section.yd-jig-additions.yd_jig_additions > div.yd-jig-lightbox-content"}}
+ok 179 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[1]/div[2]/ul/li[9]/button"}}
+ok 180 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 181 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[2]/div[2]/ul/li[5]/button"}}
+ok 182 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 183 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[1]/button"}}
+ok 184 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 185 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[1]/button"}}
+ok 186 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 187 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[8]/button"}}
+ok 188 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 189 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[8]/button"}}
+ok 190 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 191 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[1]/div[3]/div[2]/ul/li[8]/button"}}
+ok 192 {"type":"print","text":"MESSAGE: Addition added!"}
+ok 193 {"type":"sendKeysToElement","locator":{"type":"css selector","value":"textarea.yd-jig-additions-comment"},"text":"This is a meal comment! Get some food!"}
+ok 194 {"type":"clickElement","locator":{"type":"css selector","value":"textarea.yd-jig-additions-comment"}}
+ok 195 {"type":"verifyElementValue","locator":{"type":"css selector","value":"textarea.yd-jig-additions-comment"},"value":"This is a meal comment! Get some food!"}
+ok 196 {"type":"clickElement","locator":{"type":"xpath","value":"//section[7]/div[1]/div[2]/div[2]/div[2]/button"}}
+ok 197 {"type":"print","text":"MESSAGE: Meal added to cart!"}
+ok 198 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"a.yd-btn-l.yd-btn-order"}}
+ok 199 {"type":"clickElement","locator":{"type":"css selector","value":"a.yd-btn-l.yd-btn-order"}}
+ok 200 {"type":"print","text":"MESSAGE: Go to checkout!"}
+ok 201 {"type":"waitForElementPresent","locator":{"type":"css selector","value":"div.yd-jig-partnerdiscountselect-choice.yd-jig-partnerdiscount-discount.yd-discount-normal"}}
+ok 202 {"type":"clickElement","locator":{"type":"css selector","value":"div.yd-jig-partnerdiscountselect-choice.yd-jig-partnerdiscount-discount.yd-discount-normal"}}
+ok 203 {"type":"print","text":"MESSAGE: Partner discount selected!"}
+ok 204 {"type":"setElementText","locator":{"type":"css selector","value":"input[name=\"email\"]"},"text":"${email}"}

--- a/tasks/se-interpreter.js
+++ b/tasks/se-interpreter.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
             // Explicit path to directory with json files.
             path: path,
             // browser
-            browser: grunt.option("browser") || "firefox",
+            browser: grunt.option("browser") || "chrome",
             // options for webdriver
             driverOptions: {
                 hostname: grunt.option("ip") || '127.0.0.1',

--- a/worker/generator/lib/generateConfig.js
+++ b/worker/generator/lib/generateConfig.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var _ = require('lodash');
 var async = require('async');
+var configMerger = require('jmUtil').configMerge;
 var format = require('util').format;
 
 var viewHelper = require("./view");
@@ -265,7 +266,10 @@ module.exports = function (data, workerConfig, callback) {
             localConfig.predefined = generatePredefined(data);
 
             try {
-                data.config = extendWithChildPage(localConfig, message.childpage);
+                var extend = _.compose(configMerger.extendApiCallsWithModels,
+                    _.partialRight(extendWithChildPage, message.childpage));
+
+                data.config = extend(localConfig);
             } catch (e) {
                 return next(e);
             }

--- a/worker/generator/lib/generator.js
+++ b/worker/generator/lib/generator.js
@@ -726,13 +726,14 @@ var apiCalls = function (configs, emitter, callback, readyConfigs, dontCheckPlac
         configPlaceholders,
         callbackContainer = [],
         childUrl = "",
+
         apiconfig = {
-            "version": config.version,
-            "hostname": config.apiConfig.hostname,
-            "port": config.apiConfig.port,
-            "base": config.apiConfig.base,
-            "db":  config.domain,
-            "apiMessageKey": config.apiMessageKey
+            defaultValues: {
+                version: config.version,
+                db: config.domain,
+                apiMessageKey: config.apiMessageKey
+            },
+            endpoints: config.apiConfig
         };
 
     if (typeof emitter === 'function') {

--- a/worker/generator/lib/rest.js
+++ b/worker/generator/lib/rest.js
@@ -160,6 +160,7 @@ exports.addCall = function (apicall, config, paramsFromQueue, apiconfig) {
         path = "",
         placeHolders = placeholderHelper.getConfigPlaceholders(pathObj, paramsFromQueue);
 
+
     if (placeHolders) {
         pathObj = placeholderHelper.replaceConfigPlaceholders(pathObj, placeHolders);
     }

--- a/worker/lib/configMerge.js
+++ b/worker/lib/configMerge.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var es = require('event-stream'),
-    hgl = require('highland'),
+var hgl = require('highland'),
     WorkerError = require('./error').WorkerError,
     _ = require('lodash'),
     configMerge = require('jmUtil').configMerge,


### PR DESCRIPTION
Introducing mapper transformation for the data. 

### Model.ajaxRequest
In all models all `can.ajax` calls changed to `self.ajaxRequest` calls (for instance functions `statics.ajaxRequest`) should be used. 

###  .conf
Path to the mapper functions of the model should be written in `*.conf` file. in `jigs` section. The name of model starts from "§" symbol (eg. "§yd-models-discount")  example
```
"§yd-models-discount": {
            "disabled": true,
            "controller": "Yd.Models.Discount",
            "mapper": "yd/models/discount/mapper.js",
            "options": {},
            "apicalls": {
                "restaurantDiscounts": {
                    "method": "get",
                    "path": "/restaurant/{restaurantId}/discounts",
                    "predefined": true,
                    "resultSchema":  "//yd/fixture/schema/restaurant-discounts.json",
                    "cache": [
                        {
                            "to": "{url}/discounts.json"
                        }
                    ]
                }
            }
```

Now only `"mapper": "yd/models/discount/mapper.js", ` is used. all others has no effect.

### Using of the mapper.
To use the mapper, you should put `mapper:''mapperName"` to the `settings` object of ajaxRequest call. `mapperName` should be described in `mapper.js` file.

If you won't point the `mapper` key the `default` mapper will be used. Basically it does nothing, but you can change its behavior in `mapper.js` file. This allows to define mapper without changing every call of the ajaxRequest of this model.
