### PR TITLE
feat(config,api) assign alias for api endpoint and then use it in config

### DIFF
--- a/worker/generator/lib/generator.js
+++ b/worker/generator/lib/generator.js
@@ -726,13 +726,14 @@ var apiCalls = function (configs, emitter, callback, readyConfigs, dontCheckPlac
         configPlaceholders,
         callbackContainer = [],
         childUrl = "",
+
         apiconfig = {
-            "version": config.version,
-            "hostname": config.apiConfig.hostname,
-            "port": config.apiConfig.port,
-            "base": config.apiConfig.base,
-            "db":  config.domain,
-            "apiMessageKey": config.apiMessageKey
+            defaultValues: {
+                version: config.version,
+                db: config.domain,
+                apiMessageKey: config.apiMessageKey
+            },
+            endpoints: config.apiConfig
         };
 
     if (typeof emitter === 'function') {


### PR DESCRIPTION
possibility to assign an alias to api endpoint and use this alias in the
model config in case if we need some special endpoint for some apicall

cerry-pick from @jhony-chikens 

20m