### PR TITLE
feat(worker): Stream JSON files to COLIN

### DIFF
--- a/worker/parseArguments.js
+++ b/worker/parseArguments.js
@@ -30,6 +30,7 @@ module.exports = function (processArgs) {
         .option('-L, --lowprio', 'use the high priority queue')
         .option('-V, --postfix', 'use this version postfix queue')
         .option('-I, --locale <n>', 'use given locale')
+        .option('-c, --colin', 'use colin as cache layer')
         .option('-n, --namespace <n>', 'relative path from current dir to target project or just nane of project')
         .option('-f, --fixtures', 'use fixtures from project folder instead of making an api call')
         .option('-w, --write', 'write to disk the archive with generated files instead of upload them, path should be provided')

--- a/worker/uploader/index.js
+++ b/worker/uploader/index.js
@@ -12,6 +12,7 @@ var fs = require('fs'),
     _ = require('lodash'),
     async = require('async'),
     domain = require('domain'),
+    request = require('request'),
     Uploader = require('jmUtil').ydUploader,
     es = require('event-stream');
 
@@ -66,13 +67,87 @@ var writeStream = function (message) {
     });
 };
 
+var uploadToColinCache = function (data, callback) {
+    var colinConf = _.cloneDeep(config.colin);
+
+    var base = colinConf.protocol + '://' + colinConf.hostname + ':' + colinConf.port;
+    var endpoint = [base, data.domain, data.url].join('/').replace(/\.json$/, '');
+    var requestOptions = {
+        uri: endpoint,
+        method: 'PUT',
+        headers: {
+            'content-type': 'application/json'
+        },
+        body: new Buffer(data.content)
+    };
+
+    var colin = function colin(next) {
+        request(requestOptions, function (err, result, body) {
+            if (err || result.statusCode >= 300) {
+                if (body) {
+                    log('warn', body);
+                }
+                return next(err || new Error('COLIN cache: Bad status code ' + result.statusCode));
+            }
+
+            next(null, endpoint);
+        });
+    };
+
+    async.retry({ times: 5, interval: 200 }, colin, callback);
+};
+
+var colinStream = function (meta) {
+    return es.map(function (data, callback) {
+        var next = function (err, res) {
+            if (err) {
+                log('warn', 'Couldn\'t write to COLIN cache', err, {});
+            }
+            callback(null, res);
+        };
+
+        if (!args.colin) {
+            return next();
+        }
+
+        if (_.isArray(data)) {
+            log('new data to cache type: array length:', data.length);
+            return async.each(data, uploadToColinCache, next);
+        }
+
+        log('new data to cache type: string');
+
+        data = _.assign({}, meta, data, { domain: args.basedomain });
+
+        uploadToColinCache(data, next);
+    });
+};
+
+var colinStats = es.wait(function (err, body) {
+    log(err ? 'warn' : 'info', 'Finished caching to COLIN', err ? err : body, {});
+});
+
 router.addRoutes({
     pipe: function (message) {
+        var jsonFiles;
+
         message = helper.parsePipeMessage(message);
 
-        archiver.bulkArchive(message.pages)
-            .pipe(writeStream(message));
+        jsonFiles = message.pages.filter(function (page) {
+            return page.url.indexOf('json') !== -1;
+        });
 
+        es.readArray(jsonFiles)
+            .pipe(colinStream(message.metadata))
+            .pipe(colinStats)
+            .on('error', function (err) {
+                log('error', err);
+                this.emit('end');
+            })
+            .on('end', function () {
+                archiver.bulkArchive(message.pages)
+                    .pipe(writeStream(message));
+            });
     },
     'new:zip': function (data) {
         messageStream.write(data);


### PR DESCRIPTION
Files ending with .json are now pushed to COLIN
before they also get stored in CDN

Activate via `--colin` CLI flag

Needs configs from [ydFrontend #1275](https://github.com/yourdelivery/ydFrontend/pull/1275)