### PR TITLE
Make use of lowercased md5 module

### DIFF
--- a/worker/generator/lib/generator.js
+++ b/worker/generator/lib/generator.js
@@ -22,7 +22,7 @@ var placeholderHelper = require("./placeholders.js");
 var slots = require('./slots');
 var _ = require('lodash');
 var Q = require('q');
-var md5 = require('MD5');
+var md5 = require('md5');
 var gt;
 var knoxConfig;
 var saveDiskPath;

--- a/worker/lib/message.js
+++ b/worker/lib/message.js
@@ -4,7 +4,7 @@ var es = require('event-stream'),
     fs = require('fs'),
     path = require('path'),
     walk = require('walk'),
-    md5 = require('MD5'),
+    md5 = require('md5'),
     async = require('async'),
     _ = require('lodash');
 


### PR DESCRIPTION
`MD5` is outdated and has been replaced by lowercased `md5`.
Places in code where it is used haven't been updated, though..